### PR TITLE
Plugin extension and running with apprtc.appspot.com

### DIFF
--- a/www/phonertc.js
+++ b/www/phonertc.js
@@ -1,34 +1,36 @@
-var phonertc = { 
-	call: function (options) {
-		cordova.exec(
-			function (data) { 
-				if (data.type === '__answered' && options.answerCallback) {
-					options.answerCallback();
-				} else if (data.type === '__disconnected' && options.disconnectCallback) {
-					options.disconnectCallback();
-				} else {
-					options.sendMessageCallback(data);
-				}
-			},
-			null,
-			'PhoneRTCPlugin',
-			'call',
-			[options.isInitator, options.turn.host, options.turn.username, options.turn.password]);
-	},
-	receiveMessage: function (data) { 
-		cordova.exec(
-			null, 
-			null,
-			'PhoneRTCPlugin',
-			'receiveMessage',
-			[JSON.stringify(data)]);
-	},
-	disconnect: function () {
-		cordova.exec(
-			null, 
-			null,
-			'PhoneRTCPlugin',
-			'disconnect',
-			[]);
-	}
+var exec = require('cordova/exec');
+
+exports.call = function (options) {
+  exec(
+    function (data) {
+      if (data.type === '__answered' && options.answerCallback) {
+        options.answerCallback();
+      } else if (data.type === '__disconnected' && options.disconnectCallback) {
+        options.disconnectCallback();
+      } else {
+        options.sendMessageCallback(data);
+      }
+    },
+    null,
+    'PhoneRTCPlugin',
+    'call',
+    [options.isInitator, options.turn.host, options.turn.username, options.turn.password]);
+};
+
+exports.receiveMessage = function (data) {
+  exec(
+    null,
+    null,
+    'PhoneRTCPlugin',
+    'receiveMessage',
+    [JSON.stringify(data)]);
+};
+
+exports.disconnect = function () {
+  exec(
+    null,
+    null,
+    'PhoneRTCPlugin',
+    'disconnect',
+    []);
 };


### PR DESCRIPTION
I want to extend your PhoneGap iOS plugin by migrating functionality (audio and video) from the AppRTCDemo Github's iOS sample and use https://apprtc.appspot.com as a turn server. Do you thing that is possible by modifying the way of how turn/stun servers are obtained now to AppEngine? Also, for testing the plugin can you upload a demo html page which integrates the plugin call.

Many thanks.
