### PR TITLE
(Android) allow optional DTLS

### DIFF
--- a/src/android/com/dooble/phonertc/PhoneRTCPlugin.java
+++ b/src/android/com/dooble/phonertc/PhoneRTCPlugin.java
@@ -92,7 +92,7 @@ public class PhoneRTCPlugin extends CordovaPlugin {
 					cordova.getActivity().runOnUiThread(new Runnable() {
 						public void run() {
 							factory = new PeerConnectionFactory();
-							private MediaConstraints pcMediaConstraints = new MediaConstraints();
+							MediaConstraints pcMediaConstraints = new MediaConstraints();
 							pcMediaConstraints.optional.add(new MediaConstraints.KeyValuePair(
 								"DtlsSrtpKeyAgreement", "true"));
 							pc = factory.createPeerConnection(iceServers, pcMediaConstraints,


### PR DESCRIPTION
This is needed for interop with desktop browsers, as in https://github.com/joseph-onsip/sipjs-cordova

I'd offer an iOS fix as well, but I don't have an environment set up for that.
