### PR TITLE
(Android) Take into account window.devicePixelRatio when rendering video

### DIFF
--- a/src/android/com/dooble/phonertc/PhoneRTCPlugin.java
+++ b/src/android/com/dooble/phonertc/PhoneRTCPlugin.java
@@ -203,13 +203,16 @@ public class PhoneRTCPlugin extends CordovaPlugin {
 	}
 
 	VideoStreamsView createVideoView(JSONObject config) throws JSONException {
-		WebView.LayoutParams params = new WebView.LayoutParams(config.getInt("width") * 2,
-			config.getInt("height") * 2,
-			config.getInt("x"),
-			config.getInt("y"));
+		int devicePixelRatio = config.getInt("devicePixelRatio");
 
-		Point displaySize = new Point(config.getInt("width") * 2,
-			config.getInt("height") * 2);
+		int width = config.getInt("width") * devicePixelRatio;
+		int height = config.getInt("height") * devicePixelRatio;
+		int x = config.getInt("x") * devicePixelRatio;
+		int y = config.getInt("y") * devicePixelRatio;
+
+		WebView.LayoutParams params = new WebView.LayoutParams(width, height, x, y);
+
+		Point displaySize = new Point(width, height);
 
 		VideoStreamsView view = new VideoStreamsView(cordova.getActivity(), displaySize);
 		webView.addView(view, params);

--- a/www/phonertc.js
+++ b/www/phonertc.js
@@ -37,7 +37,9 @@ exports.call = function (options) {
     video = {};
     videoElements.localVideo = options.video.localVideo;
     videoElements.remoteVideo = options.video.remoteVideo;
+    var devicePixelRatio = window.devicePixelRatio || 2;
     video.localVideo = {
+      devicePixelRatio: devicePixelRatio,
       // get these values by doing a lookup on the dom
       x : videoElements.localVideo.getBoundingClientRect().left,
       y : videoElements.localVideo.getBoundingClientRect().top,
@@ -45,14 +47,13 @@ exports.call = function (options) {
       height : videoElements.localVideo.offsetHeight
     };
     video.remoteVideo = {
+      devicePixelRatio: devicePixelRatio,
       // get these values by doing a lookup on the dom
       x : videoElements.remoteVideo.getBoundingClientRect().left,
       y : videoElements.remoteVideo.getBoundingClientRect().top,
       width : videoElements.remoteVideo.offsetWidth,
       height : videoElements.remoteVideo.offsetHeight
     };
-    videoElements.localVideo.style.visibility = 'hidden';
-    videoElements.remoteVideo.style.visibility = 'hidden';
   }
 
   exec(


### PR DESCRIPTION
This correctly renders video on top of the provided <video> element, and also
therefore doesn't modify the element's style.
