### PR TITLE
phonertc.js: getLayoutParams takes window scroll into account

### DIFF
--- a/www/phonertc.js
+++ b/www/phonertc.js
@@ -26,8 +26,8 @@ function getLayoutParams (videoElement) {
   return {
     devicePixelRatio: window.devicePixelRatio || 2,
     // get these values by doing a lookup on the dom
-    x : boundingRect.left,
-    y : boundingRect.top,
+    x : boundingRect.left + window.scrollX,
+    y : boundingRect.top + window.scrollY,
     width : videoElement.offsetWidth,
     height : videoElement.offsetHeight
   };


### PR DESCRIPTION
This helps reposition rendered videos correctly when device orientation changes.
