### PR TITLE
Fixing Previous PR: Replacing '\r\n' in SDP with '\n' and splitting on that

### DIFF
--- a/src/ios/PhoneRTCDelegate.m
+++ b/src/ios/PhoneRTCDelegate.m
@@ -122,7 +122,8 @@ didSetSessionDescriptionWithError:(NSError *)error {
 + (NSString *)preferISAC:(NSString *)origSDP {
     int mLineIndex = -1;
     NSString* isac16kRtpMap = nil;
-    NSArray* lines = [origSDP componentsSeparatedByString:@"\r?\n"];
+    origSDP = [origSDP stringByReplacingOccurrencesOfString:@"\r\n" withString:@"\n"];
+    NSArray* lines = [origSDP componentsSeparatedByString:@"\n"];
     NSRegularExpression* isac16kRegex = [NSRegularExpression
                                          regularExpressionWithPattern:@"^a=rtpmap:(\\d+) ISAC/16000[\r]?$"
                                          options:0


### PR DESCRIPTION
Replacing '\r\n' in SDP with '\n' and splitting on that, instead of incorrectly splitting on a Regex Pattern. @joseph-onsip caught my silly error and suggested this fix.

Previous PR: https://github.com/alongubkin/phonertc/pull/29
