### PR TITLE
VideoStreamsView.java: don't mirror video when rendering

### DIFF
--- a/src/android/com/dooble/phonertc/VideoStreamsView.java
+++ b/src/android/com/dooble/phonertc/VideoStreamsView.java
@@ -245,7 +245,7 @@ public class VideoStreamsView
 
   // Remote image should span the full screen.
   private static final FloatBuffer remoteVertices = directNativeFloatBuffer(
-      new float[] { 1, 1, 1, -1, -1, 1, -1, -1 });
+      new float[] { -1, 1, -1, -1, 1, 1, 1, -1 });
 
   // Texture Coordinates mapping the entire texture.
   private static final FloatBuffer textureCoords = directNativeFloatBuffer(


### PR DESCRIPTION
This renders remote video correctly. Local video is still rendered the same way as remote video (non-mirrored), which might be a little unexpected for the user, but it's not as bad as mirroring remote video, in my opinion.
