### PR TITLE
Check if _videoView is null to avoid crash

### DIFF
--- a/src/android/com/dooble/phonertc/PhoneRTCPlugin.java
+++ b/src/android/com/dooble/phonertc/PhoneRTCPlugin.java
@@ -195,13 +195,17 @@ public class PhoneRTCPlugin extends CordovaPlugin {
 		} else if (action.equals("hideVideoView")) {
 			cordova.getActivity().runOnUiThread(new Runnable() {
 				public void run() {
-					_videoView.setVisibility(View.GONE);
+					if (_videoView != null) {
+						_videoView.setVisibility(View.GONE);
+					}
 				}
 			});
 		} else if (action.equals("showVideoView")) {
 			cordova.getActivity().runOnUiThread(new Runnable() {
 				public void run() {
-					_videoView.setVisibility(View.VISIBLE);
+					if (_videoView != null) {
+						_videoView.setVisibility(View.VISIBLE);
+					}
 				}
 			});		
 		}


### PR DESCRIPTION
Check if _videoView is null to avoid crash when calling showVideoViev/hideVideoView early from JavaScript