### PR TITLE
Check if queuedRemoteCandidates is nil to avoid iOS crash

### DIFF
--- a/src/ios/SessionDescriptionDelegate.swift
+++ b/src/ios/SessionDescriptionDelegate.swift
@@ -62,10 +62,11 @@ class SessionDescriptionDelegate : UIResponder, RTCSessionDescriptionDelegate {
     }
     
     func drainRemoteCandidates() {
-        for candidate in self.session.queuedRemoteCandidates! {
-            self.session.peerConnection.addICECandidate(candidate)
+        if self.session.queuedRemoteCandidates != nil {
+            for candidate in self.session.queuedRemoteCandidates! {
+                self.session.peerConnection.addICECandidate(candidate)
+            }
+            self.session.queuedRemoteCandidates = nil
         }
-        
-        self.session.queuedRemoteCandidates = nil
     }
 }


### PR DESCRIPTION
Check if queuedRemoteCandidates is already nil to avoid crash when returning from background mode in iOS (sometimes happens when a call has been made while in the background)