### PR TITLE
Use MediaStreamTrack.stop() to stop streaming, not MediaStream.stop()

### DIFF
--- a/src/browser/PhoneRTCProxy.js
+++ b/src/browser/PhoneRTCProxy.js
@@ -381,7 +381,7 @@ function addRemoteStream(stream) {
 
 function removeRemoteStream(videoView) {
   console.log(remoteVideoViews);
-  document.body.removeChild(videoView);
+  videoView.parentNode.removeChild(videoView);
   remoteVideoViews.splice(videoView, 1);
   console.log(remoteVideoViews);
 

--- a/src/browser/PhoneRTCProxy.js
+++ b/src/browser/PhoneRTCProxy.js
@@ -487,7 +487,9 @@ function onSessionDisconnect(sessionKey) {
     }
 
     localStreams.forEach(function (stream) {
-      stream.stop();
+      stream.getTracks().forEach( function(track) { 
+        track.stop();
+      });
     });
 
     localStreams = [];

--- a/src/ios/PhoneRTCPlugin.swift
+++ b/src/ios/PhoneRTCPlugin.swift
@@ -147,8 +147,9 @@ class PhoneRTCPlugin : CDVPlugin {
     
     func hideVideoView(command: CDVInvokedUrlCommand) {
         dispatch_async(dispatch_get_main_queue()) {
-            self.localVideoView!.hidden = true;
-            
+            if (self.localVideoView != nil) {
+                self.localVideoView!.hidden = true;
+            }    
             for remoteVideoView in self.remoteVideoViews {
                 remoteVideoView.videoView.hidden = true;
             }
@@ -157,8 +158,9 @@ class PhoneRTCPlugin : CDVPlugin {
     
     func showVideoView(command: CDVInvokedUrlCommand) {
         dispatch_async(dispatch_get_main_queue()) {
-            self.localVideoView!.hidden = false;
-            
+            if (self.localVideoView != nil) {
+                self.localVideoView!.hidden = false;
+            }    
             for remoteVideoView in self.remoteVideoViews {
                 remoteVideoView.videoView.hidden = false;
             } 


### PR DESCRIPTION
Use MediaStreamTrack.stop() to stop streaming, not MediaStream.stop() . See https://developers.google.com/web/updates/2015/07/mediastream-deprecations .